### PR TITLE
Version at the end of the path, works as well

### DIFF
--- a/src/Helper/VersionFromUri.php
+++ b/src/Helper/VersionFromUri.php
@@ -29,7 +29,7 @@ class VersionFromUri implements VersionParser
     public function getVersion(): string
     {
         $uri = $this->request->getPathInfo();
-        if (! preg_match('/\/v([0-9.]+)\//i', $uri, $version)) {
+        if (! preg_match('/\/v([0-9.]+)\/?/i', $uri, $version)) {
             return self::LOWEST_VERSION;
         };
 


### PR DESCRIPTION
Make the trailing slash optional in the path info matching so the matcher can match urls like `\resource\v1.0`